### PR TITLE
Fix crash when resetting flag

### DIFF
--- a/Code/BatterySwitch.cs
+++ b/Code/BatterySwitch.cs
@@ -119,7 +119,7 @@ namespace Celeste.Mod.Batteries {
         public override void Removed(Scene scene) {
             base.Removed(scene);
             if (!persistent && alwaysFlag) {
-                SceneAs<Level>().Session.SetFlag(FlagName, false);
+                (scene as Level).Session.SetFlag(FlagName, false);
             }
         }
 


### PR DESCRIPTION
base.Removed already sets the entity's Scene property to null, which is what SceneAs accesses. Since Removed gets the scene as a parameter, we can just use that.