### PR TITLE
Add color customization options

### DIFF
--- a/Ahorn/entities/battery.jl
+++ b/Ahorn/entities/battery.jl
@@ -2,7 +2,7 @@ module BatteriesBattery
 
 using ..Ahorn, Maple
 
-@mapdef Entity "batteries/battery" Battery(x::Integer, y::Integer, maxCharge::Integer=500, initalCharge::Integer=500, dischargeRate::Integer=80, oneUse::Bool=false, onlyFits::Integer=-1, ignoreBarriers::Bool=false)
+@mapdef Entity "batteries/battery" Battery(x::Integer, y::Integer, maxCharge::Integer=500, initalCharge::Integer=500, dischargeRate::Integer=80, oneUse::Bool=false, onlyFits::Integer=-1, ignoreBarriers::Bool=false, particleColorInfinite::String="00ffff", particleColorFull::String="00ff00", particleColorHalf::String="fafad2", particleColorLow::String="ff4500")
 
 const placements = Ahorn.PlacementDict(
     "Battery (Batteries)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/battery.jl
+++ b/Ahorn/entities/battery.jl
@@ -2,7 +2,7 @@ module BatteriesBattery
 
 using ..Ahorn, Maple
 
-@mapdef Entity "batteries/battery" Battery(x::Integer, y::Integer, maxCharge::Integer=500, initalCharge::Integer=500, dischargeRate::Integer=80, oneUse::Bool=false, onlyFits::Integer=-1, ignoreBarriers::Bool=false, particleColorInfinite::String="00ffff", particleColorFull::String="00ff00", particleColorHalf::String="fafad2", particleColorLow::String="ff4500")
+@mapdef Entity "batteries/battery" Battery(x::Integer, y::Integer, maxCharge::Integer=500, initalCharge::Integer=500, dischargeRate::Integer=80, oneUse::Bool=false, onlyFits::Integer=-1, ignoreBarriers::Bool=false, particleColorInfinite::String="00ffff", particleColorFull::String="00ff00", particleColorHalf::String="fafad2", particleColorLow::String="ff4500", deathEffectColor::String="228b22")
 
 const placements = Ahorn.PlacementDict(
     "Battery (Batteries)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/battery_switch.jl
+++ b/Ahorn/entities/battery_switch.jl
@@ -2,7 +2,7 @@ module BatteriesBatterySwitch
 
 using ..Ahorn, Maple
 
-@mapdef Entity "batteries/battery_switch" BatterySwitch(x::Integer, y::Integer, rightSide::Bool=false, ceiling::Bool=false, persistent::Bool=false, horizontal::Bool=true, alwaysFlag::Bool=false)
+@mapdef Entity "batteries/battery_switch" BatterySwitch(x::Integer, y::Integer, rightSide::Bool=false, ceiling::Bool=false, persistent::Bool=false, horizontal::Bool=true, alwaysFlag::Bool=false, particleColorA::String="00ff00", particleColorB::String="ffffff", glowColor::String="00ffff")
 
 const placements = Ahorn.PlacementDict()
 

--- a/Code/Battery.cs
+++ b/Code/Battery.cs
@@ -37,11 +37,12 @@ namespace Celeste.Mod.Batteries {
         private float swatTimer;
         private float hardVerticalHitSoundCooldown = 0f;
         private ParticleType particle;
+        private Color deathEffectColor;
         private bool fresh;
         private EntityID id;
         private int spinnerHits = 0;
 
-        public Battery(Vector2 position, int initalCharge, int maxCharge, int dischargeRate, bool oneUse, bool ignoreBarriers, int onlyFits, EntityID id)
+        public Battery(Vector2 position, int initalCharge, int maxCharge, int dischargeRate, Color deathEffectColor, bool oneUse, bool ignoreBarriers, int onlyFits, EntityID id)
             : base(position) {
             previousPosition = position;
             this.id = id;
@@ -71,6 +72,7 @@ namespace Celeste.Mod.Batteries {
             MaxCharge = maxCharge;
             Charge = initalCharge;
             DischargeRate = dischargeRate;
+            this.deathEffectColor = deathEffectColor;
             this.oneUse = oneUse;
             this.ignoreBarriers = ignoreBarriers;
             this.onlyFits = onlyFits;
@@ -79,6 +81,7 @@ namespace Celeste.Mod.Batteries {
         public Battery(EntityData e, Vector2 offset, EntityID id)
             : this(e.Position + offset, e.Int("initalCharge", 500),
                    e.Int("maxCharge", 500), e.Int("dischargeRate", 80),
+                   e.HexColor("deathEffectColor", Color.ForestGreen),
                    e.Bool("oneUse"), e.Bool("ignoreBarriers", false),
                    e.Int("onlyFits", -1), id) {
             LoadParticles(e);
@@ -398,7 +401,7 @@ namespace Celeste.Mod.Batteries {
 
                 dead = true;
                 Audio.Play("event:/char/madeline/death", Position);
-                Add(new DeathEffect(Color.ForestGreen, Center - Position));
+                Add(new DeathEffect(deathEffectColor, Center - Position));
                 sprite.Visible = false;
                 Charge = 0;
                 Depth = -1000000;

--- a/Code/Battery.cs
+++ b/Code/Battery.cs
@@ -74,7 +74,6 @@ namespace Celeste.Mod.Batteries {
             this.oneUse = oneUse;
             this.ignoreBarriers = ignoreBarriers;
             this.onlyFits = onlyFits;
-            LoadParticles();
         }
 
         public Battery(EntityData e, Vector2 offset, EntityID id)
@@ -82,20 +81,21 @@ namespace Celeste.Mod.Batteries {
                    e.Int("maxCharge", 500), e.Int("dischargeRate", 80),
                    e.Bool("oneUse"), e.Bool("ignoreBarriers", false),
                    e.Int("onlyFits", -1), id) {
+            LoadParticles(e);
         }
 
         private string FlagName => GetFlagName(id);
 
         public static string GetFlagName(EntityID id) => "battery_" + id.Key;
 
-        public static void LoadParticles() {
-            P_Infinite.Color = Color.Cyan;
+        private static void LoadParticles(EntityData e) {
+            P_Infinite.Color = e.HexColor("particleColorInfinite", Color.Cyan);
             P_Infinite.ColorMode = ParticleType.ColorModes.Static;
-            P_Full.Color = Color.Lime;
+            P_Full.Color = e.HexColor("particleColorFull", Color.Lime);
             P_Full.ColorMode = ParticleType.ColorModes.Static;
-            P_Half.Color = Color.LightGoldenrodYellow;
+            P_Half.Color = e.HexColor("particleColorHalf", Color.LightGoldenrodYellow);
             P_Half.ColorMode = ParticleType.ColorModes.Static;
-            P_Low.Color = Color.OrangeRed;
+            P_Low.Color = e.HexColor("particleColorLow", Color.OrangeRed);
             P_Low.ColorMode = ParticleType.ColorModes.Static;
         }
 

--- a/Loenn/entities/battery.lua
+++ b/Loenn/entities/battery.lua
@@ -1,8 +1,9 @@
 local battery = {}
 
 local COLOR_CYAN = "00ffff"
-local COLOR_LIME = "00ff00"
+local COLOR_FOREST_GREEN = "228b22"
 local COLOR_LIGHT_GOLDENROD_YELLOW = "fafad2"
+local COLOR_LIME = "00ff00"
 local COLOR_ORANGE_RED = "ff4500"
 
 battery.name = "batteries/battery"
@@ -21,7 +22,8 @@ battery.placements = {
             particleColorInfinite = COLOR_CYAN,
             particleColorFull = COLOR_LIME,
             particleColorHalf = COLOR_LIGHT_GOLDENROD_YELLOW,
-            particleColorLow = COLOR_ORANGE_RED
+            particleColorLow = COLOR_ORANGE_RED,
+            deathEffectColor = COLOR_FOREST_GREEN
         }
     },
     {
@@ -36,7 +38,8 @@ battery.placements = {
             particleColorInfinite = COLOR_CYAN,
             particleColorFull = COLOR_LIME,
             particleColorHalf = COLOR_LIGHT_GOLDENROD_YELLOW,
-            particleColorLow = COLOR_ORANGE_RED
+            particleColorLow = COLOR_ORANGE_RED,
+            deathEffectColor = COLOR_FOREST_GREEN
         }
     }
 }
@@ -56,10 +59,13 @@ battery.fieldInformation = {
     },
     particleColorLow = {
         fieldType = "color"
+    },
+    deathEffectColor = {
+        fieldType = "color"
     }
 }
 
-battery.fieldOrder = {"x", "y", "maxCharge", "initalCharge", "dischargeRate", "onlyFits", "particleColorInfinite", "particleColorFull", "particleColorHalf", "particleColorLow", "ignoreBarriers", "oneUse"}
+battery.fieldOrder = {"x", "y", "maxCharge", "initalCharge", "dischargeRate", "onlyFits", "particleColorInfinite", "particleColorFull", "particleColorHalf", "particleColorLow", "deathEffectColor", "ignoreBarriers", "oneUse"}
 
 battery.texture = "batteries/battery/full0"
 battery.justification = {0.5, 1}

--- a/Loenn/entities/battery.lua
+++ b/Loenn/entities/battery.lua
@@ -1,5 +1,10 @@
 local battery = {}
 
+local COLOR_CYAN = "00ffff"
+local COLOR_LIME = "00ff00"
+local COLOR_LIGHT_GOLDENROD_YELLOW = "fafad2"
+local COLOR_ORANGE_RED = "ff4500"
+
 battery.name = "batteries/battery"
 battery.depth = 100
 
@@ -12,7 +17,11 @@ battery.placements = {
             dischargeRate = 80,
             oneUse = false,
             onlyFits = -1,
-            ignoreBarriers = false
+            ignoreBarriers = false,
+            particleColorInfinite = COLOR_CYAN,
+            particleColorFull = COLOR_LIME,
+            particleColorHalf = COLOR_LIGHT_GOLDENROD_YELLOW,
+            particleColorLow = COLOR_ORANGE_RED
         }
     },
     {
@@ -23,7 +32,11 @@ battery.placements = {
             dischargeRate = 0,
             oneUse = false,
             onlyFits = -1,
-            ignoreBarriers = false
+            ignoreBarriers = false,
+            particleColorInfinite = COLOR_CYAN,
+            particleColorFull = COLOR_LIME,
+            particleColorHalf = COLOR_LIGHT_GOLDENROD_YELLOW,
+            particleColorLow = COLOR_ORANGE_RED
         }
     }
 }
@@ -31,8 +44,22 @@ battery.placements = {
 battery.fieldInformation = {
     onlyFits = {
         fieldType = "integer"
+    },
+    particleColorInfinite = {
+        fieldType = "color"
+    },
+    particleColorFull = {
+        fieldType = "color"
+    },
+    particleColorHalf = {
+        fieldType = "color"
+    },
+    particleColorLow = {
+        fieldType = "color"
     }
 }
+
+battery.fieldOrder = {"x", "y", "maxCharge", "initalCharge", "dischargeRate", "onlyFits", "particleColorInfinite", "particleColorFull", "particleColorHalf", "particleColorLow", "ignoreBarriers", "oneUse"}
 
 battery.texture = "batteries/battery/full0"
 battery.justification = {0.5, 1}

--- a/Loenn/entities/battery_switch.lua
+++ b/Loenn/entities/battery_switch.lua
@@ -3,6 +3,10 @@ local utils = require("utils")
 
 local battery_switch = {}
 
+local COLOR_AQUA = "00ffff"
+local COLOR_LIME = "00ff00"
+local COLOR_WHITE = "ffffff"
+
 battery_switch.name = "batteries/battery_switch"
 
 battery_switch.placements = {
@@ -14,6 +18,9 @@ battery_switch.placements = {
             ceiling = false,
             rightSide = false,
             horizontal = false,
+            particleColorA = COLOR_AQUA,
+            particleColorB = COLOR_WHITE,
+            glowColor = COLOR_LIME
         }
     },
     {
@@ -24,6 +31,9 @@ battery_switch.placements = {
             ceiling = true,
             rightSide = false,
             horizontal = false,
+            particleColorA = COLOR_AQUA,
+            particleColorB = COLOR_WHITE,
+            glowColor = COLOR_LIME
         }
     },
     {
@@ -34,6 +44,9 @@ battery_switch.placements = {
             ceiling = false,
             rightSide = false,
             horizontal = true,
+            particleColorA = COLOR_LIME,
+            particleColorB = COLOR_WHITE,
+            glowColor = COLOR_AQUA
         }
     },
     {
@@ -44,11 +57,26 @@ battery_switch.placements = {
             ceiling = false,
             rightSide = true,
             horizontal = true,
+            particleColorA = COLOR_LIME,
+            particleColorB = COLOR_WHITE,
+            glowColor = COLOR_AQUA
         }
     },
 }
 
-battery_switch.fieldOrder = {"x", "y", "horizontal", "rightSide", "ceiling", "persistent", "alwaysFlag"}
+battery_switch.fieldOrder = {"x", "y", "particleColorA", "particleColorB", "glowColor", "horizontal", "rightSide", "ceiling", "persistent", "alwaysFlag"}
+
+battery_switch.fieldInformation = {
+    particleColorA = {
+        fieldType = "color"
+    },
+    particleColorB = {
+        fieldType = "color"
+    },
+    glowColor = {
+        fieldType = "color"
+    }
+}
 
 function battery_switch.sprite(room, entity)
     local texture = "batteries/battery_switch/insert8"

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -1,9 +1,12 @@
 mods.batteries.name=Batteries
+
 # Battery Switch
 entities.batteries/battery_switch.placements.name.up=Battery Switch (Up)
 entities.batteries/battery_switch.placements.name.down=Battery Switch (Down)
 entities.batteries/battery_switch.placements.name.left=Battery Switch (Left)
 entities.batteries/battery_switch.placements.name.right=Battery Switch (Right)
+entities.batteries/battery_switch.attributes.name.particleColorA=Particle Color 1
+entities.batteries/battery_switch.attributes.name.particleColorB=Particle Color 2
 entities.batteries/battery_switch.attributes.description.horizontal=Whether the switch is horizontally aligned. Vertical if not ticked.
 entities.batteries/battery_switch.attributes.description.alwaysFlag=If this is enabled, the switch will always set the flag "batterySwitch_(room name):(id)" when activated. Otherwise, it will only set the flag if persistent.
 entities.batteries/battery_switch.attributes.description.rightSide=Whether the switch should be attached to the right side of the block as opposed to the left. Has no effect on vertical switches.
@@ -11,19 +14,25 @@ entities.batteries/battery_switch.attributes.description.persistent=If this is e
 entities.batteries/battery_switch.attributes.description.ceiling=Whether the switch should be attached to the bottom side of the block as opposed to the top. Has no effect on horizontal switches.
 
 # Battery
-
 entities.batteries/battery.placements.name.default=Battery
 entities.batteries/battery.placements.name.permanent=Battery (Permanent)
 entities.batteries/battery.attributes.name.initalCharge=Initial Charge
+entities.batteries/battery.attributes.name.particleColorInfinite=Particle Color (Infinite Charge)
+entities.batteries/battery.attributes.name.particleColorFull=Particle Color (Full Charge)
+entities.batteries/battery.attributes.name.particleColorHalf=Particle Color (Half Charge)
+entities.batteries/battery.attributes.name.particleColorLow=Particle Color (Low Charge)
 entities.batteries/battery.attributes.description.oneUse=If this is enabled, the battery will not respawn after it is used to activate a switch.
 entities.batteries/battery.attributes.description.onlyFits=The entity id of the switch that this battery fits into. If unset or below 0, this battery will be able to fit into any switch.
 entities.batteries/battery.attributes.description.ignoreBarriers=If this is enabled, this battery will be able to pass through seeker barriers without being destroyed.
 entities.batteries/battery.attributes.description.maxCharge=The maximum charge that the battery can hold.
 entities.batteries/battery.attributes.description.initalCharge=The charge that the battery starts with.
 entities.batteries/battery.attributes.description.dischargeRate=The rate at which the battery loses charge (in units/second).
+entities.batteries/battery.attributes.description.particleColorInfinite=The particle color of the battery when it has infinite charge.
+entities.batteries/battery.attributes.description.particleColorFull=The particle color of the battery when it is at full charge.
+entities.batteries/battery.attributes.description.particleColorHalf=The particle color of the battery when it has half charge.
+entities.batteries/battery.attributes.description.particleColorLow=The particle color of the battery when it has low charge.
 
 # Battery Power Refill
-
 entities.batteries/power_refill.placements.name.default=Power Refill
 entities.batteries/power_refill.attributes.description.oneUse=If this is enabled, the refill will not respawn after being used.
 


### PR DESCRIPTION
Although batteries and battery switches can be easily resprited, their particle and death effect colors are hardcoded into the entity, which made non-green reskins mismatch. This is a proposal to expose particle colors for the 4 battery states, the battery's death effect color, and battery switch particle and glow colors for customization in Lonn and Ahorn. This contribution adds the following options:

**Batteries**
- Particle Color (Infinite)
- Particle Color (Full)
- Particle Color (Half)
- Particle Color (Low)
- Death Effect Color

**Battery Switch**
- Particle Color 1
- Particle Color 2
- Glow Color

https://github.com/CommunalHelper/Batteries/assets/35340310/ec7e1737-d938-4855-aa1c-e8510152ea7a

